### PR TITLE
specify license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "kinda like JSON.stringify, but for generating JSON that is meant for JS objects",
   "author": "Dan Lynch <pyramation@gmail.com>",
   "homepage": "https://github.com/pyramation/strfy-js#readme",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "main": "main/index.js",
   "module": "module/index.js",
   "typings": "types/index.d.ts",


### PR DESCRIPTION
Similar to launchsql/pgsql-parser#222, this PR specifies the license in package.json to make it compatible with the [dependency review GitHub action](https://github.com/actions/dependency-review-action)